### PR TITLE
Start timer only on a new file

### DIFF
--- a/PizzaTowerAny%.asl
+++ b/PizzaTowerAny%.asl
@@ -5,7 +5,7 @@ state("PizzaTower")
 
 start
 {
-	return current.roomNumber == 757;
+	return current.roomNumber == 757 && old.roomNumber == 798;
 }
  
 split


### PR DESCRIPTION
Current behavior: start the timer anytime you are on the first tower room, causing false starts when opening any file.
New behavior: start the timer when the room switches from the intro cutscene to the first tower room.