### PR TITLE
Fix livesplit freeze and small improvements

### DIFF
--- a/PizzaTowerAny%.asl
+++ b/PizzaTowerAny%.asl
@@ -1,69 +1,6 @@
 state("PizzaTower"){}
 
-init
-{
-	// sigscan
-	var exe = modules.First();
-	var scn = new SignatureScanner(game, exe.BaseAddress, exe.ModuleMemorySize);
-	Func<IntPtr, IntPtr> onFound = addr => addr + 0x4 + game.ReadValue<int>(addr);
-
-	// for room id / numbers
-	var roomNumberTrg = new SigScanTarget(2, "89 3D ???????? 48 3B 1D");
-	// for room names array
-	var roomArrayTrg = new SigScanTarget(5, "74 0C 48 8B 05 ???????? 48 8B 04 D0");
-	// for the length of the room names array
-	var roomArrLenTrg = new SigScanTarget(3, "48 3B 15 ???????? 73 ?? 48 8B 0D");
-
-	// find static address for the room id
-	vars.roomNumberPtr = onFound(scn.Scan(roomNumberTrg));
-	
-	// stall until a room is loaded to make sure the room names are already set in memory when their sigscan happens
-	print("[ASL] Waiting for the game to load...");
-	current.roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
-	while (current.roomNumber == 0) {
-		current.roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
-	}
-	print("[ASL] Game loaded!");
-	
-	// get address of the room names array
-	var arr = game.ReadPointer(onFound(scn.Scan(roomArrayTrg)));
-	// get room names array length
-	var len = game.ReadValue<int>(onFound(scn.Scan(roomArrLenTrg)));
-
-	// add locally the room names to an array
-	vars.RoomNames = new string[len];
-	for (int i = 0; i < len; i++)
-	{
-		var name = game.ReadString(game.ReadPointer(arr + 0x8 * i), ReadStringType.UTF8, 64);
-		vars.RoomNames[i] = name;
-	}
-
-	current.RoomName = "";
-	old.RoomName = "";
-	current.roomNumber = 0;
-	old.roomNumber = 0;
-	
-}
-
-update
-{
-	old.roomNumber = current.roomNumber;
-	current.roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
-	old.RoomName = current.RoomName;
-	current.RoomName = vars.RoomNames[current.roomNumber];
-}
-
-start
-{
-	return old.RoomName == "Finalintro" && current.RoomName == "tower_entrancehall";
-}
-
-reset
-{
-	return old.RoomName != "Mainmenu" && current.RoomName == "Mainmenu";
-}
-
-split
+startup
 {
 	string[] hubRooms = {
 		"tower_entrancehall",
@@ -75,6 +12,7 @@ split
 		"tower_5",
 		"boss_pizzafacehub"
 	};
+	vars.hubRooms = hubRooms;
 
 	string[] lastLevelRooms = {
 		"rank_room",
@@ -104,7 +42,76 @@ split
 		"boss_fakepepkey",
 		"boss_pizzafacefinale"
 	};
+	vars.lastLevelRooms = lastLevelRooms;
+}
+
+init
+{
+	// sigscan
+	var exe = modules.First();
+	var scn = new SignatureScanner(game, exe.BaseAddress, exe.ModuleMemorySize);
+	Func<IntPtr, IntPtr> onFound = addr => addr + 0x4 + game.ReadValue<int>(addr);
+
+	// for room id / numbers
+	var roomNumberTrg = new SigScanTarget(2, "89 3D ???????? 48 3B 1D");
+	// for room names array
+	var roomArrayTrg = new SigScanTarget(5, "74 0C 48 8B 05 ???????? 48 8B 04 D0");
+	// for the length of the room names array
+	var roomArrLenTrg = new SigScanTarget(3, "48 3B 15 ???????? 73 ?? 48 8B 0D");
+
+	// find static address for the room id
+	vars.roomNumberPtr = onFound(scn.Scan(roomNumberTrg));
 	
-	return Array.IndexOf(lastLevelRooms, old.RoomName) != -1 && Array.IndexOf(hubRooms, current.RoomName) != -1
+	// stall until a room is loaded (or the game closes) to make sure the room names are already set in memory when their sigscan happens
+	print("[ASL] Waiting for the game to load...");
+	current.roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
+	while (current.roomNumber == 0 && !game.HasExited) {
+		current.roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
+	}
+
+    if (game.HasExited) {
+        print("[ASL] Game closed, aborting...");
+        return;
+    }
+
+	print("[ASL] Game loaded!");
+	
+	// get address of the room names array
+	var arr = game.ReadPointer(onFound(scn.Scan(roomArrayTrg)));
+	// get room names array length
+	var len = game.ReadValue<int>(onFound(scn.Scan(roomArrLenTrg)));
+
+	// add locally the room names to an array
+	vars.RoomNames = new string[len];
+	for (int i = 0; i < len; i++)
+	{
+		var name = game.ReadString(game.ReadPointer(arr + 0x8 * i), ReadStringType.UTF8, 64);
+		vars.RoomNames[i] = name;
+	}
+
+	old.RoomName = "";
+	current.RoomName = "";
+}
+
+update
+{
+	int roomNumber = game.ReadValue<int>((IntPtr)vars.roomNumberPtr);
+	old.RoomName = current.RoomName;
+	current.RoomName = vars.RoomNames[roomNumber];
+}
+
+start
+{
+	return old.RoomName == "Finalintro" && current.RoomName == "tower_entrancehall";
+}
+
+reset
+{
+	return old.RoomName != "Finalintro" && current.RoomName == "Finalintro";
+}
+
+split
+{
+	return Array.IndexOf(vars.lastLevelRooms, old.RoomName) != -1 && Array.IndexOf(vars.hubRooms, current.RoomName) != -1
 		|| old.RoomName == "tower_entrancehall" && current.RoomName == "rank_room";
 }


### PR DESCRIPTION
* Fix livesplit freeze when closing the game right before it showed the initial logos.
* Reset in intro cutscene instead of the main menu to give more breathing room between fake splits and resets.
* Small optimizations: Set useful room name arrays once instead of every cycle and remove unused variables.